### PR TITLE
[ADD] 매칭 수락 버튼 userId 확인 추가

### DIFF
--- a/config/baseResponseStatus.js
+++ b/config/baseResponseStatus.js
@@ -101,6 +101,8 @@ module.exports = {
     PICKCOMMENT_ROLE_WRONG:{"isSuccess": false, "code": 2704, "message": "댓글을 다는 role이 잘못 되었습니다."},
     PICKCOMMENT_USERID_WRONG:{"isSuccess": false, "code": 2705, "message": "댓글 작성자와 일치하지 않습니다."},
 
+    MATCHING_USERID_WRONG:{"isSuccess": false, "code": 2901, "message": "글 작성자와 일치하지 않습니다."},
+
     // response err
     SIGNUP_REDUNDANT_ID : { "isSuccess": false, "code": 3001, "message":"중복된 아이디입니다." },
     SIGNIN_ID_WRONG : { "isSuccess": false, "code": 3002, "message": "아이디가 잘못 되었습니다." },

--- a/src/app/Mentoring/mentoringController.js
+++ b/src/app/Mentoring/mentoringController.js
@@ -578,8 +578,8 @@ exports.getPickMenteesCom = async function (req, res){
     console.log(pickStatus[0].status)
     if (pickStatus[0].status === 1)
         pickMenteesComListResult = await mentoringProvider.retrievePickMenteeComList(pickId); // 댓글 전부 보여주기
-    //else if (pickStatus[0].status === 0)
-        //pickMenteesComListResult = await mentoringProvider.retrievePickMenteeCom(pickId); // 매칭된 댓글만 보여주기
+    // else if (pickStatus[0].status === 0)
+    //     pickMenteesComListResult = await mentoringProvider.retrievePickMenteeCom(userId, pickId); // 매칭된 댓글만 보여주기
     return res.send(response(baseResponse.SUCCESS, pickMenteesComListResult))
     
 }
@@ -654,6 +654,12 @@ exports.postMatching = async function(req, res){
     const userId = req.verifiedToken.userId;
     const pickId = req.params.pickId;
     const pickCommentId = req.params.pickCommentId;
+
+    // 구인글 쓴 사람한테는 수락 버튼을 보여주기 -> pick 테이블의 userId가 로그인한 userId랑 같을 때만
+    const userIdCheck = await mentoringProvider.userIdCheck(pickId); // pickId로 글쓴 userId 확인
+    console.log(userIdCheck[0][0].userId, userId)
+    if (userIdCheck[0][0].userId !== userId)
+        return res.send(errResponse(baseResponse.MATCHING_USERID_WRONG))
 
     const pickStatus = await mentoringProvider.pickStatusCheck(pickId) // pick의 status 확인
     console.log(pickStatus[0].status)

--- a/src/app/Mentoring/mentoringDao.js
+++ b/src/app/Mentoring/mentoringDao.js
@@ -357,6 +357,29 @@ async function updateStatus(connection, pickId){
     return statusRow;
 }
 
+// 매칭된 사람 댓글만 보여지게 하기
+// 매칭 테이블은 matchingId, userId, targetId만 있음
+// 알 수 있는 건 userId와 파라미터로 넘어오는 pickId
+async function selectMatchingCom(connection, userId, pickId){
+  const selectMatchingComQuery = `
+          SELECT pickCommentId, pickId, nickname, contents
+          FROM pickcomment
+          JOIN matching ON userId = ? and pickId = ?;
+        `
+    const matchingCom = await connection.query(selectMatchingComQuery, userId, pickId);
+    return matchingCom;
+}
+
+async function userIdCheck(connection, pickId){
+  const userIdCheckQuery = `
+          SELECT userId
+          FROM pick
+          WHERE pickId = ?;
+        `
+    const userIdCheckRow = await connection.query(userIdCheckQuery, pickId);
+    return userIdCheckRow;
+}
+
   module.exports = {
     selectPickMentee,
     selectPickMentor,
@@ -386,6 +409,8 @@ async function updateStatus(connection, pickId){
     deleteMenteesCom,
     pickStatusCheck,
     insertMatching,
-    updateStatus
+    updateStatus,
+    selectMatchingCom,
+    userIdCheck
   };
   

--- a/src/app/Mentoring/mentoringProvider.js
+++ b/src/app/Mentoring/mentoringProvider.js
@@ -93,6 +93,14 @@ exports.retrievePickMenteeComList = async function(pickId) {
   return pickMenteeComListResult
 }
 
+exports.retrievePickMenteeCom = async function(userId, pickId){
+  const connection = await pool.getConnection(async (conn) => conn);
+  const pickMenteeComListResult = await mentoringDao.selectMatchingCom(connection, userId, pickId);
+  connection.release();
+
+  return pickMenteeComListResult
+}
+
 exports.pickComCheckByUserId = async function(pickComCheckParams){
   const connection = await pool.getConnection(async (conn) => conn);
   const comCheckResult = await mentoringDao.selectPickComByUserId(connection, pickComCheckParams);
@@ -115,4 +123,12 @@ exports.pickStatusCheck = async function(pickId){
   connection.release();
 
   return pickStatusResult;
+}
+
+exports.userIdCheck = async function(pickId){
+  const connection = await pool.getConnection(async (conn) => conn);
+  const userIdCheckResult = await mentoringDao.userIdCheck(connection, pickId);
+  connection.release();
+
+  return userIdCheckResult;
 }


### PR DESCRIPTION
1. 매칭 완료된 구인글 -> 매칭된 댓글만 남겨서 보여주기
2. 매칭 완료 안된 구인글 -> 댓글 전부다 보여주기
3. 매칭 완료 안된 구인글 -> 글쓴 사람한테 수락 버튼 보여주기

1) status가 1이면 pick의 userId 값과 pickComment의 userId, pick의 subject를 matching에 insert
-> 만약 status가 0이면 에러
-> status는 0으로 update
2) if status가 1이면 전체 댓글 조회
3) status가 0이면 pickComment 테이블이랑 매칭 테이블을 join해서 targetId가 pickComment 테이블의 userId랑 같은거만 보여지게 하기
4) 글쓴 사람한테 수락 버튼 보여주기 -> pick 테이블의 userId가 로그인한 userId랑 같을 때만 보여지게 하기

3)은 아직 진행 중입니다!