### PR TITLE
[CHORE] SELECT userId, pickId, role 칼럼 추가

### DIFF
--- a/src/app/Mentoring/mentoringDao.js
+++ b/src/app/Mentoring/mentoringDao.js
@@ -1,7 +1,7 @@
   // 멘토 구인글 전체 조회
 async function selectPickMentor(connection) {
   const selectPickMentorListQuery = `
-                    SELECT pickId, title, subject, concat(date_format(periodStart, "%y.%m"), "~", date_format(periodEnd, "%y.%m")) as period, mentoringMethod, wishGender
+                    SELECT userId, pickId, title, subject, concat(date_format(periodStart, "%y.%m"), "~", date_format(periodEnd, "%y.%m")) as period, mentoringMethod, wishGender, role
                     FROM pick 
                     WHERE role = 2
                     order by pickId desc;
@@ -14,7 +14,7 @@ async function selectPickMentor(connection) {
   // 멘티 구인글 전체 조회
   async function selectPickMentee(connection) {
     const selectPickMenteeListQuery = `
-                    SELECT pickId, title, subject, concat(date_format(periodStart, "%y.%m"), "~", date_format(periodEnd, "%y.%m")) as period, mentoringMethod, wishGender
+                    SELECT userId, pickId, title, subject, concat(date_format(periodStart, "%y.%m"), "~", date_format(periodEnd, "%y.%m")) as period, mentoringMethod, wishGender, role
                     FROM pick 
                     WHERE role = 1
                     order by pickId desc;
@@ -26,7 +26,7 @@ async function selectPickMentor(connection) {
     // 멘토 구인글 부분 조회(5개)
    async function selectPickMentorMain(connection) {
     const selectPickMentorMainListQuery = `
-                      SELECT pickId, title, subject, concat(date_format(periodStart, "%y.%m"), "~", date_format(periodEnd, "%y.%m")) as period, mentoringMethod, wishGender
+                      SELECT userId, pickId, title, subject, concat(date_format(periodStart, "%y.%m"), "~", date_format(periodEnd, "%y.%m")) as period, mentoringMethod, wishGender, role
                       FROM pick
                       WHERE role = 2
                       ORDER BY viewCount desc
@@ -40,7 +40,7 @@ async function selectPickMentor(connection) {
     // 멘티 구인글 부분 조회(5개)
     async function selectPickMenteeMain(connection) {
       const selectPickMenteeMainListQuery = `
-                      SELECT pickId, title, subject, concat(date_format(periodStart, "%y.%m"), "~", date_format(periodEnd, "%y.%m")) as period, mentoringMethod, wishGender
+                      SELECT userId, pickId, title, subject, concat(date_format(periodStart, "%y.%m"), "~", date_format(periodEnd, "%y.%m")) as period, mentoringMethod, wishGender, role
                       FROM pick 
                       WHERE role = 1
                       ORDER BY viewCount desc
@@ -83,7 +83,7 @@ async function selectPickMentor(connection) {
     // 특정 멘토 구인글 조회
    async function selectPickMentorById(connection, pickId) {
      const selectPickMentorIdQuery = `
-                 SELECT u.nickname, p.title, p.contents, CASE p.status when 1 THEN '모집중' else '모집완료' END as status, p.mentoringMethod, p.mentorCareer, p.subject, p.periodStart, p.periodEnd, p.wishGender, p.viewCount, date(p.createdAt) as 'createdAt', date(p.updatedAt) as 'updatedAt' 
+                 SELECT u.userId, u.nickname, u.role, p.pickId, p.title, p.contents, p.status, p.mentoringMethod, p.mentorCareer, p.subject, p.periodStart, p.periodEnd, p.wishGender, p.viewCount, date(p.createdAt) as 'createdAt', date(p.updatedAt) as 'updatedAt' 
                  FROM pick p, user u 
                  WHERE p.role=2 AND p.pickId=? AND p.userId=u.userId;
                  `;
@@ -94,7 +94,7 @@ async function selectPickMentor(connection) {
     // 특정 멘티 구인글 조회
     async function selectPickMenteeById(connection, pickId) {
       const selectPickMenteeIdQuery = `
-                SELECT u.nickname, p.title, p.contents, CASE p.status when 1 THEN '모집중' else '모집완료' END as status, p.mentoringMethod, p.menteeLevel, p.subject, p.periodStart, p.periodEnd, p.wishGender, p.viewCount, date(p.createdAt) as 'createdAt', date(p.updatedAt) as 'updatedAt' 
+                SELECT u.userId, u.nickname, u.role, p.pickId, p.title, p.contents, p.status, p.mentoringMethod, p.menteeLevel, p.subject, p.periodStart, p.periodEnd, p.wishGender, p.viewCount, date(p.createdAt) as 'createdAt', date(p.updatedAt) as 'updatedAt' 
                 FROM pick p, user u 
                 WHERE p.role=1 AND p.pickId=? AND p.userId=u.userId;
                   `;
@@ -207,7 +207,7 @@ async function selectUserRole(connection, userId){
 // 멘토 구인글에 달린 댓글 조회
 async function selectMentorCom(connection, pickId) {
   const selectMentorComQuery = `
-    SELECT user.userId, pickComment.pickId, pickComment.pickCommentId, user.nickname, pickComment.contents, user.userImg, pickComment.createdAt
+    SELECT user.userId, pickComment.pickId, pickComment.pickCommentId, user.nickname, user.role, pickComment.contents, user.userImg, pickComment.createdAt
     FROM pickComment
     JOIN user ON pickComment.userId=user.userId and pickId = ?;
   `
@@ -272,7 +272,7 @@ async function insertMenteesCom(connection, insertMenteesComParams){
 // 멘티 구인글에 달린 댓글 조회
 async function selectMenteeCom(connection, pickId) {
   const selectMenteeComQuery = `
-      SELECT user.userId, pickComment.pickId, pickComment.pickCommentId, user.nickname, pickComment.contents, user.userImg, pickComment.createdAt
+      SELECT user.userId, pickComment.pickId, pickComment.pickCommentId, user.nickname, user.role, pickComment.contents, user.userImg, pickComment.createdAt
       FROM pickComment
       JOIN user ON pickComment.userId=user.userId and pickId = ?;
   `
@@ -362,7 +362,7 @@ async function updateStatus(connection, pickId){
 // 알 수 있는 건 userId와 파라미터로 넘어오는 pickId
 async function selectMatchingCom(connection, pickId){
   const selectMatchingComQuery = `
-        SELECT pickComment.userId, pickComment.pickId, pickComment.pickCommentId, user.nickname, pickComment.contents, user.userImg, pickComment.createdAt
+        SELECT pickComment.userId, pickComment.pickId, pickComment.pickCommentId, user.nickname, user.role, pickComment.contents, user.userImg, pickComment.createdAt
         FROM pickComment
         JOIN user ON user.userId = pickComment.userId
         WHERE pickComment.userId = (

--- a/src/app/MyPage/myPageDao.js
+++ b/src/app/MyPage/myPageDao.js
@@ -44,7 +44,7 @@ async function selectMyComPickMentee(connection, userId) {
 // 멘토링 내역 조회
 async function mentoringList(connection, userId){
     const mentoringListQuery = `
-        SELECT user.nickname, IF(datediff(pick.periodEnd,sysdate())>0, "멘토링 진행 중", "멘토링 종료") as state, user.userImg
+        SELECT matching.matchingId, user.nickname, IF(datediff(pick.periodEnd,sysdate())>0, 1, 0) as state, user.userImg
         FROM matching 
         JOIN user ON user.userId = ${userId}
         JOIN pick ON pick.userId = ${userId}

--- a/src/app/User/userDao.js
+++ b/src/app/User/userDao.js
@@ -69,7 +69,7 @@ async function selectUserAccount(connection, id) {
   // 멘토 전체 조회(최근 가입한 순)
   async function selectMentor(connection) {
     const selectMentorListQuery = `
-                  SELECT userId, nickname, userImg 
+                  SELECT userId, nickname, userImg, role
                   FROM user 
                   WHERE role=1
                   ORDER BY userId DESC;
@@ -83,7 +83,7 @@ async function selectUserAccount(connection, id) {
   // 멘티 전체 조회(최근 가입한 순)
   async function selectMentee(connection) {
     const selectMenteeListQuery = `
-                  SELECT userId, nickname, userImg 
+                  SELECT userId, nickname, userImg, role
                   FROM user 
                   WHERE role=2
                   ORDER BY userId DESC;
@@ -96,7 +96,7 @@ async function selectUserAccount(connection, id) {
     // 멘토 부분 조회(최신 5개)
     async function selectNewMentor(connection) {
       const selectNewMentorListQuery = `
-                    SELECT userId, nickname, userImg 
+                    SELECT userId, nickname, userImg, role
                     FROM user 
                     WHERE role=1
                     ORDER BY userId DESC
@@ -111,7 +111,7 @@ async function selectUserAccount(connection, id) {
     // 멘티 부분 조회(최신 5개)
     async function selectNewMentee(connection) {
       const selectMenteeListQuery = `
-                    SELECT userId, nickname, userImg 
+                    SELECT userId, nickname, userImg, role 
                     FROM user 
                     WHERE role=2
                     ORDER BY userId DESC
@@ -125,7 +125,7 @@ async function selectUserAccount(connection, id) {
   // 특정 멘토 정보 조회
   async function selectMentorById(connection, userId){
     const selectMentorByIdQuery = `
-                SELECT name, nickname, birth, education, department, address, introduce, userImg
+                SELECT userId, name, nickname, birth, education, department, address, introduce, userImg, role
                 FROM user
                 WHERE role=1 and userId=?
                 `;
@@ -137,7 +137,7 @@ async function selectUserAccount(connection, id) {
   // 특정 멘티 정보 조회
   async function selectMenteeById(connection, userId){
     const selectMenteeByIdQuery = `
-                SELECT name, nickname, birth, education, grade, address, introduce, userImg
+                SELECT userId, name, nickname, birth, education, grade, address, introduce, userImg, role
                 FROM user
                 WHERE role=2 and userId=?
                 `;


### PR DESCRIPTION
클라이언트 측이 필요하다고 한 userId, pickId, role 칼럼을 SELECT할 때 추가해놓았습니다.
- 멘토/멘티 구인글 조회
- 멘토/멘티 구인글 댓글 조회
- 메인화면 멘토/멘티 조회

클라이언트 측에서 status 값은 INT으로 보내달라고 요청하여
매칭 완료될 때 pick의 '모집중', '모집완료'라고 변환하여 출력하던 status 값을 1과 0으로 수정하였고, 
멘토링 내역 조회에서 '활동 중', '활동완료'라고 변환하여 출력하던 state 값 또한 1과 0으로 수정하였습니다.