### PR TITLE
[MOD] 인증번호 date 값 받아오는 코드 수정

### DIFF
--- a/src/app/User/userController.js
+++ b/src/app/User/userController.js
@@ -15,28 +15,6 @@ const axios = require('axios');
 const Cache = require('memory-cache');
 const CryptoJS = require('crypto-js');
 
-const date = Date.now().toString();
-const uri = secret_key.NCP_serviceID;
-const secretKey = secret_key.NCP_secretKey;
-const accessKey = secret_key.NCP_accessKEY;
-const method = 'POST';
-const space = " ";
-const newLine = "\n";
-const url = `https://sens.apigw.ntruss.com/sms/v2/services/${uri}/messages`;
-const url2 = `/sms/v2/services/${uri}/messages`;
-
-const  hmac = CryptoJS.algo.HMAC.create(CryptoJS.algo.SHA256, secretKey);
-
-hmac.update(method);
-hmac.update(space);
-hmac.update(url2);
-hmac.update(newLine);
-hmac.update(date);
-hmac.update(newLine);
-hmac.update(accessKey);
-
-const hash = hmac.finalize();
-const signature = hash.toString(CryptoJS.enc.Base64);
 
 /**
  * API No. 0
@@ -53,6 +31,30 @@ exports.getTest = async function (req, res) {
  * [POST] /users/send
  */
 exports.send = async function (req, res) {
+    
+    let date = Date.now().toString();
+    const uri = secret_key.NCP_serviceID;
+    const secretKey = secret_key.NCP_secretKey;
+    const accessKey = secret_key.NCP_accessKEY;
+    const method = 'POST';
+    const space = " ";
+    const newLine = "\n";
+    const url = `https://sens.apigw.ntruss.com/sms/v2/services/${uri}/messages`;
+    const url2 = `/sms/v2/services/${uri}/messages`;
+
+    const  hmac = CryptoJS.algo.HMAC.create(CryptoJS.algo.SHA256, secretKey);
+
+    hmac.update(method);
+    hmac.update(space);
+    hmac.update(url2);
+    hmac.update(newLine);
+    hmac.update(date);
+    hmac.update(newLine);
+    hmac.update(accessKey);
+
+    const hash = hmac.finalize();
+    const signature = hash.toString(CryptoJS.enc.Base64);
+    
     const phoneNumber = req.body.phoneNum;
 
     Cache.del(phoneNumber);
@@ -77,7 +79,7 @@ exports.send = async function (req, res) {
         contentType: 'COMM',
         countryCode: '82',
         // from은 발송번호
-        from: '',
+        from: '01063381227',
         content: `[본인 확인] 인증번호 [${verifyCode}]를 입력해주세요.`,
         messages: [
           {


### PR DESCRIPTION
휴대폰 인증번호 발송 관련해서, 서버가 켜지고 일정 시간 이후부터 인증 번호가 날라가지 않는다는 이슈가 있었습니다.

시간 관련된 제한을 둔 코드는 존재하지 않아서 NCP API 문서를 찾아보니
 API gateway와 5분 이상 시간 차이가 나면 유효하지 않는다고 판단하여 발송하지 않는다고 합니다! 

기존의 코드는 서버가 시작되자마자 date 값을 받아왔는데, send 함수 내부에 시간을 받아오도록 하여 인증 번호 발송할 때마다 date 값을 받아올 수 있도록 고쳤습니다. 현재 로컬에서는 5분 이상 시간이 흘러도 인증 번호가 날라오는 것을 확인하였습니다!

서버와 클라이언트 측에서도 확인이 필요한 것으로 보입니다 :-)