### PR TITLE
[MOD] 매칭된 구인글 댓글 조회 불가로 코드 수정

### DIFF
--- a/src/app/Mentoring/mentoringController.js
+++ b/src/app/Mentoring/mentoringController.js
@@ -477,9 +477,11 @@ exports.getPickMentorsCom = async function (req, res){
         console.log(pickMentorsComListResult[0])
         return res.send(response(baseResponse.SUCCESS, pickMentorsComListResult))}
     else if (pickStatus[0].status === 0){
-        pickMentorsComListResult = await mentoringProvider.retrievePickMentorCom(pickId); // 매칭된 댓글만 보여주기
-        console.log(pickMentorsComListResult[0])
-        return res.send(response(baseResponse.SUCCESS, pickMentorsComListResult[0]))}
+        return res.send(response(baseResponse.SUCCESS, []))
+    }
+        //pickMentorsComListResult = await mentoringProvider.retrievePickMentorCom(pickId); // 매칭된 댓글만 보여주기
+        //console.log(pickMentorsComListResult[0])
+        //return res.send(response(baseResponse.SUCCESS, pickMentorsComListResult[0]))}
 }
 
 /**
@@ -590,8 +592,11 @@ exports.getPickMenteesCom = async function (req, res){
         pickMenteesComListResult = await mentoringProvider.retrievePickMenteeComList(pickId); // 댓글 전부 보여주기
         return res.send(response(baseResponse.SUCCESS, pickMenteesComListResult))}
     else if (pickStatus[0].status === 0){
-        pickMenteesComListResult = await mentoringProvider.retrievePickMenteeCom(pickId); // 매칭된 댓글만 보여주기
-        return res.send(response(baseResponse.SUCCESS, pickMenteesComListResult[0]))}
+            return res.send(response(baseResponse.SUCCESS, []))
+    }
+    //else if (pickStatus[0].status === 0){
+    //    pickMenteesComListResult = await mentoringProvider.retrievePickMenteeCom(pickId); // 매칭된 댓글만 보여주기
+    //    return res.send(response(baseResponse.SUCCESS, pickMenteesComListResult[0]))}
     
 }
 


### PR DESCRIPTION
현재 매칭된 댓글만 조회를 하려면, DB를 수정해서 매칭 테이블을 참조하는 모든 코드를 수정해야 하는 대공사가 필요하여 댓글 조회 불가로 변경하였습니다.

이전의 코드 상태로는 1번이 코딩 과목 구인글을 올려서 A, B가 댓글을 달았는데 그중에 A랑 되었고, 
1번이 코딩 과목 구인글을 또 올려서 B가 이 구인글에 댓글을 달아 B와도 매칭이 되었을 때 매칭된 댓글 조회에서 A와 B가 동시에 조회되는 문제가 생겼습니다.
이 문제는 B가 1번과 A가 매칭이 되었던 구인글에 댓글을 단 적이 있어서 매칭된 댓글 조회할 때 sql 조건에서 1번과 매칭이 되어있으면서 A와 매칭된 구인글의 pickId가 동일하게 있어 함께 조회된다는 문제가 있었습니다.

sql 문을 작성할 때 받을 수 있는 값이 pickId 하나 밖에 없고, 매칭 테이블은 userId와 targetId를 바로 받게 되면서 targetId의 pickCommentId를 확인하지 못하다보니 위 같은 문제가 발생하고 있습니다. 이 부분은 리팩토링 기간 동안 매칭 테이블의 userId와 targetId를 pickId와 pickCommentId로 받도록 수정하여 코드를 전반적으로 고치거나 이것이 어렵다면 현재처럼 매칭이 될 경우 댓글 조회를 막는 걸 유지할 예정입니다.